### PR TITLE
Update unsquash-4.c

### DIFF
--- a/unsquash-4.c
+++ b/unsquash-4.c
@@ -33,6 +33,14 @@ int read_fragment_table_4(long long *directory_table_end)
 	int res, i;
 	int bytes = SQUASHFS_FRAGMENT_BYTES(sBlk.s.fragments);
 	int  indexes = SQUASHFS_FRAGMENT_INDEXES(sBlk.s.fragments);
+	size_t bytes = SQUASHFS_FRAGMENT_BYTES(sBlk.s.fragments);
+	size_t  indexes = SQUASHFS_FRAGMENT_INDEXES(sBlk.s.fragments);
+
+	if ( bytes > indexes ) {
+		EXIT_UNSQUASH("read_fragment_table: stack overflow via integer overflow averted;\n\t" \
+		"indexes = %zu\n\tbytes=%zu\n", indexes, bytes);
+	}
+
 	long long fragment_table_index[indexes];
 
 	TRACE("read_fragment_table: %d fragments, reading %d fragment indexes "


### PR DESCRIPTION
Averts a stack overflow in read_fragment_table_4 at fragment_table_index[] via integer overflow.
This can be achieved by maliciously manipulating sBlk.s.fragments so that the SQUASHFS_FRAGMENT_X macros overflow the result.


```
Parallel unsquashfs: Using 8 processors
ASAN:SIGSEGV
=================================================================
==8221==ERROR: AddressSanitizer: stack-overflow on address 0x7ffef3ae9608 (pc 0x000000559011 bp 0x7ffef49e9670 sp 0x7ffef3ae9610 T0)
    #0 0x559010 in read_fragment_table_4 /home/septimus/vr/squashfs-vr/squashfs-tools/unsquash-4.c:40:9
    #1 0x525073 in main /home/septimus/vr/squashfs-vr/squashfs-tools/unsquashfs.c:2763:5
    #2 0x7fb56c533a3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x20a3f)
    #3 0x418468 in _start (/home/septimus/vr/squashfs-vr/squashfs-tools/unsquashfs+0x418468)
SUMMARY: AddressSanitizer: stack-overflow /home/septimus/vr/squashfs-vr/squashfs-tools/unsquash-4.c:40:9 in read_fragment_table_4
==8221==ABORTING
```